### PR TITLE
add a test for the runtime upgrades

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -1,0 +1,35 @@
+import { assert } from 'chai';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
+describe('Runtime Upgrades', () => {
+  const getApi = async (url) => {
+    // Construct API provider
+    const wsProvider = new WsProvider(url);
+    const api = await ApiPromise.create({ provider: wsProvider });
+    return api;
+  };
+
+  describe('Runtime Upgrades by Block', async () => {
+    it('should return the latest runtime version for Moonbase Alpha', async () => {
+      const api = await getApi('wss://wss.api.moonbase.moonbeam.network');
+      const runtime = await api.query.system.lastRuntimeUpgrade();
+      // Assert the runtime is equal to the latest version we have on the docs
+      assert.equal(runtime.toJSON().specVersion, 2602);
+      api.disconnect();
+    });
+    it('should return the latest runtime version for Moonriver', async () => {
+      const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
+      const runtime = await api.query.system.lastRuntimeUpgrade();
+      // Assert the runtime is equal to the latest version we have on the docs
+      assert.equal(runtime.toJSON().specVersion, 2602);
+      api.disconnect();
+    });
+    it('should return the latest runtime version for Moonbeam', async () => {
+      const api = await getApi('wss://wss.api.moonbeam.network');
+      const runtime = await api.query.system.lastRuntimeUpgrade();
+      // Assert the runtime is equal to the latest version we have on the docs
+      assert.equal(runtime.toJSON().specVersion, 2602);
+      api.disconnect();
+    });
+  });
+})


### PR DESCRIPTION
With the addition of the runtime upgrades page on the docs site (https://github.com/moonbeam-foundation/moonbeam-docs/pull/819), this test ensures that we have the latest runtime version listed on that page. This will also be helpful for letting us know when we need to update links that use `networks.<network>.spec_version` 