### PR TITLE
update the balances transfer dispatchable to use transferAllowDeath

### DIFF
--- a/test/builders/build/substrate-api/polkadotjs-api.js
+++ b/test/builders/build/substrate-api/polkadotjs-api.js
@@ -104,7 +104,7 @@ describe('Polkadot.js API', function () {
       const bob = ethers.Wallet.createRandom().address;
 
       // Form the transaction
-      const tx = api.tx.balances.transfer(bob, 12345n);
+      const tx = api.tx.balances.transferKeepAlive(bob, 12345n);
 
       // Sign and send the transaction
       const txHash = await tx.signAndSend(aliceFromUri);
@@ -134,8 +134,8 @@ describe('Polkadot.js API', function () {
 
       // Construct a list of transactions to batch
       const txs = [
-        api.tx.balances.transfer(bob, 12345n),
-        api.tx.balances.transfer(charlie, 12345n),
+        api.tx.balances.transferKeepAlive(bob, 12345n),
+        api.tx.balances.transferKeepAlive(charlie, 12345n),
       ];
 
       // Estimate the fees as RuntimeDispatchInfo, using the signer (either
@@ -159,8 +159,8 @@ describe('Polkadot.js API', function () {
 
       // Construct a list of transactions to batch
       const txs = [
-        api.tx.balances.transfer(bob, 12345n),
-        api.tx.balances.transfer(charlie, 12345n),
+        api.tx.balances.transferKeepAlive(bob, 12345n),
+        api.tx.balances.transferKeepAlive(charlie, 12345n),
       ];
 
       // Construct the batch and send the transactions

--- a/test/builders/build/substrate-api/polkadotjs-api.js
+++ b/test/builders/build/substrate-api/polkadotjs-api.js
@@ -104,7 +104,7 @@ describe('Polkadot.js API', function () {
       const bob = ethers.Wallet.createRandom().address;
 
       // Form the transaction
-      const tx = api.tx.balances.transferKeepAlive(bob, 12345n);
+      const tx = api.tx.balances.transferAllowDeath(bob, 12345n);
 
       // Sign and send the transaction
       const txHash = await tx.signAndSend(aliceFromUri);
@@ -134,8 +134,8 @@ describe('Polkadot.js API', function () {
 
       // Construct a list of transactions to batch
       const txs = [
-        api.tx.balances.transferKeepAlive(bob, 12345n),
-        api.tx.balances.transferKeepAlive(charlie, 12345n),
+        api.tx.balances.transferAllowDeath(bob, 12345n),
+        api.tx.balances.transferAllowDeath(charlie, 12345n),
       ];
 
       // Estimate the fees as RuntimeDispatchInfo, using the signer (either
@@ -159,8 +159,8 @@ describe('Polkadot.js API', function () {
 
       // Construct a list of transactions to batch
       const txs = [
-        api.tx.balances.transferKeepAlive(bob, 12345n),
-        api.tx.balances.transferKeepAlive(charlie, 12345n),
+        api.tx.balances.transferAllowDeath(bob, 12345n),
+        api.tx.balances.transferAllowDeath(charlie, 12345n),
       ];
 
       // Construct the batch and send the transactions

--- a/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
+++ b/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
-describe.only('Overview of XC-20s - Current List of External XC-20s', function () {
+describe('Overview of XC-20s - Current List of External XC-20s', function () {
   const getApi = async (wssEndpoint) => {
     const wsProvider = new WsProvider(wssEndpoint);
     const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });


### PR DESCRIPTION
The `transfer` function of the balances pallet has been deprecated, so this updates the tests to use `transferAllowDeath` instead

Related docs PRs: 
- EN: https://github.com/moonbeam-foundation/moonbeam-docs/pull/830
- CN: https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/385

⚠️⚠️ This shouldn't be merged until the version on the server is updated by opslayer, otherwise we'll continue to get test failure notifications ⚠️⚠️