### PR TITLE
update moonbeam's xc-20 count to include xcvASTR and xcvMANTA

### DIFF
--- a/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
+++ b/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
@@ -18,7 +18,7 @@ describe('Overview of XC-20s - Current List of External XC-20s', function () {
       const api = await getApi('wss://wss.api.moonbeam.network');
 
       const assets = await api.query.assets.asset.entries();
-      assert.equal(assets.length, 35n);
+      assert.equal(assets.length, 37n);
 
       api.disconnect();
     }).timeout(15000);


### PR DESCRIPTION
update moonbeam's xc-20 count to include xcvASTR and xcvMANTA

made the relevant changes to the docs site in these PRs: https://github.com/moonbeam-foundation/moonbeam-docs/pull/866 and https://github.com/moonbeam-foundation/moonbeam-docs-cn/pull/412