### PR TITLE
update number of xc20s to account for xcPEAQ, xcUNQ, and xcDED

### DIFF
--- a/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
+++ b/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
@@ -18,7 +18,7 @@ describe('Overview of XC-20s - Current List of External XC-20s', function () {
       const api = await getApi('wss://wss.api.moonbeam.network');
 
       const assets = await api.query.assets.asset.entries();
-      assert.equal(assets.length, 38n);
+      assert.equal(assets.length, 41n);
 
       api.disconnect();
     }).timeout(15000);


### PR DESCRIPTION
This PR bumps the number of xc-20s from 38 to 41 to account for the new xc-20s: xcPEAQ, xcUNQ, and xcDED