### PR TITLE
bump moonriver to runtime 2901

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@polkadot/util-crypto": "^12.6.2",
         "chai": "^5.1.0",
         "dotenv": "^16.4.5",
-        "ethers": "^6.12.0",
+        "ethers": "^6.12.1",
         "fs": "^0.0.1-security",
         "hardhat": "^2.22.3",
         "mocha": "^10.4.0",
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.0.tgz",
-      "integrity": "sha512-zL5NlOTjML239gIvtVJuaSk0N9GQLi1Hom3ZWUszE5lDTQE/IVB62mrPkQ2W1bGcZwVGSLaetQbWNQSvI4rGDQ==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.1.tgz",
+      "integrity": "sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==",
       "funding": [
         {
           "type": "individual",
@@ -6965,9 +6965,9 @@
       }
     },
     "ethers": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.0.tgz",
-      "integrity": "sha512-zL5NlOTjML239gIvtVJuaSk0N9GQLi1Hom3ZWUszE5lDTQE/IVB62mrPkQ2W1bGcZwVGSLaetQbWNQSvI4rGDQ==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.1.tgz",
+      "integrity": "sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==",
       "requires": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@polkadot/util-crypto": "^12.6.2",
     "chai": "^5.1.0",
     "dotenv": "^16.4.5",
-    "ethers": "^6.12.0",
+    "ethers": "^6.12.1",
     "fs": "^0.0.1-security",
     "hardhat": "^2.22.3",
     "mocha": "^10.4.0",

--- a/test/builders/build/eth-api/dev-env/hardhat/package-lock.json
+++ b/test/builders/build/eth-api/dev-env/hardhat/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.0.5",
-        "ethers": "^6.12.0",
+        "ethers": "^6.12.1",
         "hardhat": "^2.22.3"
       }
     },
@@ -1681,9 +1681,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.0.tgz",
-      "integrity": "sha512-zL5NlOTjML239gIvtVJuaSk0N9GQLi1Hom3ZWUszE5lDTQE/IVB62mrPkQ2W1bGcZwVGSLaetQbWNQSvI4rGDQ==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.1.tgz",
+      "integrity": "sha512-j6wcVoZf06nqEcBbDWkKg8Fp895SS96dSnTCjiXT+8vt2o02raTn4Lo9ERUuIVU5bAjoPYeA+7ytQFexFmLuVw==",
       "funding": [
         {
           "type": "individual",

--- a/test/builders/build/eth-api/dev-env/hardhat/package.json
+++ b/test/builders/build/eth-api/dev-env/hardhat/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.5",
-    "ethers": "^6.12.0",
+    "ethers": "^6.12.1",
     "hardhat": "^2.22.3"
   },
   "type": "module"

--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -5,7 +5,7 @@ describe('Runtime Upgrades', () => {
   const getApi = async (url) => {
     // Construct API provider
     const wsProvider = new WsProvider(url);
-    const api = await ApiPromise.create({ provider: wsProvider });
+    const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
     return api;
   };
 

--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -21,7 +21,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 2801);
+      assert.equal(runtime.toJSON().specVersion, 2901);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonbeam', async () => {


### PR DESCRIPTION
This PR updates to the latest packages and bumps the runtime version to 2901 for moonriver