### PR TITLE
switch how we connect and disconnect from the api

### DIFF
--- a/test/builders/build/substrate-api/polkadotjs-api.js
+++ b/test/builders/build/substrate-api/polkadotjs-api.js
@@ -19,47 +19,36 @@ describe('Polkadot.js API', function () {
   const index = 0;
   const ethDerPath = "m/44'/60'/0'/0/" + index;
 
-  const getApi = async () => {
+  // Define the API
+  let api;
+
+  before(async function () {
     // Construct API provider
     const wsProvider = new WsProvider('ws://localhost:9944');
-    const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
-
-    return api;
-  };
+     api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
+  })
 
   describe('Querying for Information - State Queries', async () => {
     it('should return the account balance and nonce', async () => {
-      const api = await getApi();
-
       const bob = ethers.Wallet.createRandom().address;
       const { nonce, data: balance } = await api.query.system.account(bob);
 
       assert.equal(nonce, 0n);
       assert.equal(balance.free, 0n);
-
-      api.disconnect();
     });
   });
 
   describe('Querying for Information - RPC Queries', async () => {
     it('should return the chain name', async () => {
-      const api = await getApi();
-
       const chain = await api.rpc.system.chain();
 
-      assert.equal(chain, 'Moonbase Development Testnet');
-      api.disconnect();
-    });
+      assert.equal(chain, 'Moonbase Development Testnet');    });
     it('should return the last block number and hash', async () => {
-      const api = await getApi();
-
       const lastHeader = await api.rpc.chain.getHeader();
 
       // Cannot predict the hash or block number but we can test that a value is returned
       assert.exists(lastHeader.number);
       assert.exists(lastHeader.hash);
-
-      api.disconnect();
     });
   });
 
@@ -94,8 +83,6 @@ describe('Polkadot.js API', function () {
 
   describe('Transactions - Sending Basic Transactions', async () => {
     it('should sign and send a transaction successfully', async () => {
-      const api = await getApi();
-
       // Create a keyring instance
       const keyring = new Keyring({ type: 'ethereum' });
 
@@ -115,15 +102,11 @@ describe('Polkadot.js API', function () {
 
       assert.exists(txHash);
       assert.equal(balance.free, 12345n);
-
-      api.disconnect();
     });
   });
 
   describe('Transactions - Batching Transactions', async () => {
     it('should estimate the fees for a batch transaction', async () => {
-      const api = await getApi();
-
       // Create a keyring instance
       const keyring = new Keyring({ type: 'ethereum' });
 
@@ -143,12 +126,8 @@ describe('Polkadot.js API', function () {
       const info = await api.tx.utility.batch(txs).paymentInfo(aliceFromUri);
 
       expect(info.weight.refTime.toNumber()).to.be.greaterThan(0);
-
-      api.disconnect();
     });
     it('should sign and send a batch transaction successfully', async () => {
-      const api = await getApi();
-
       // Create a keyring instance
       const keyring = new Keyring({ type: 'ethereum' });
 
@@ -174,8 +153,10 @@ describe('Polkadot.js API', function () {
       assert.exists(txHash);
       assert.equal(bobBalance.free, 12345n);
       assert.equal(charlieBalance.free, 12345n);
-
-      api.disconnect();
     });
   });
+
+  after(async function () {
+    return api.disconnect();
+  })
 });

--- a/test/builders/get-started/eth-compare/account-balances.js
+++ b/test/builders/get-started/eth-compare/account-balances.js
@@ -3,7 +3,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 import { ethers } from 'ethers';
 import { stringToHex } from '@polkadot/util';
 
-describe.only('Account Balances', () => {
+describe('Account Balances', () => {
   const alice = {
     address: '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac',
     pk: '0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133',

--- a/test/builders/get-started/eth-compare/account-balances.js
+++ b/test/builders/get-started/eth-compare/account-balances.js
@@ -3,23 +3,23 @@ import { ApiPromise, WsProvider } from '@polkadot/api';
 import { ethers } from 'ethers';
 import { stringToHex } from '@polkadot/util';
 
-describe('Account Balances', () => {
+describe.only('Account Balances', () => {
   const alice = {
     address: '0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac',
     pk: '0x5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133',
   };
 
-  const getApi = async () => {
+  // Define the API
+  let api;
+
+  before(async function () {
     // Construct API provider
-    const wsProvider = new WsProvider('ws://127.0.0.1:9944');
-    const api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
-    return api;
-  };
+    const wsProvider = new WsProvider('ws://localhost:9944');
+     api = await ApiPromise.create({ provider: wsProvider, noInitWarn: true });
+  })
 
   describe('Moonbeam Account Balances - Retrieve Your Balance', async () => {
     it('should return the balance of an account', async () => {
-      // Get API provider
-      const api = await getApi();
       // Create new account
       const bob = ethers.Wallet.createRandom().address;
       // Get the balance of the new account
@@ -27,12 +27,8 @@ describe('Account Balances', () => {
       // Bob's initial balance should be 0
       const freeBalance = balanceData.toJSON().free;
       assert.equal(freeBalance, 0);
-
-      api.disconnect();
     });
     it('should return the balance locks of an account', async () => {
-      // Get API provider
-      const api = await getApi();
       // Get the balance locks for Alice
       const locksData = await api.query.balances.locks(alice.address);
       // Alice should have one balance lock since she is the default collator on dev nodes
@@ -40,8 +36,10 @@ describe('Account Balances', () => {
       const lockId = stringToHex('stkngcol');
       // Assert that she has a balance lock for collating
       assert.equal(lockId, collatorLock.id);
-
-      api.disconnect();
     });
   });
+
+  after(async function () {
+    return api.disconnect();
+  })
 });


### PR DESCRIPTION
Use `before` and `after` hooks to connect and disconnect the API to avoid disconnection errors (why tests were failing)