### PR TITLE
Moonbase 3800

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -14,7 +14,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonbase.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 3702);
+      assert.equal(runtime.toJSON().specVersion, 3800);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonriver', async () => {


### PR DESCRIPTION
This pull request includes a single change to the test file `test/builders/build/runtime-upgrades.js`. The change updates the expected `specVersion` in the runtime upgrade test for Moonbase from `3702` to `3800`.