### PR TITLE
moonriver 3800

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -21,7 +21,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 3702);
+      assert.equal(runtime.toJSON().specVersion, 3800);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonbeam', async () => {


### PR DESCRIPTION
This pull request includes a small update to a test file to reflect the latest runtime version for Moonriver. The change updates the expected `specVersion` in the assertion from `3702` to `3800` in the `describe('Runtime Upgrades', () => {` block of `test/builders/build/runtime-upgrades.js`.