### PR TITLE
3800 Moonbeam Runtime Upgrade

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -28,7 +28,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 3702);
+      assert.equal(runtime.toJSON().specVersion, 3800);
       api.disconnect();
     });
   });


### PR DESCRIPTION
This pull request makes a minor update to a test in `test/builders/build/runtime-upgrades.js`, updating the expected runtime `specVersion` to match the latest version.

* Updated the expected `specVersion` in the runtime upgrade test from `3702` to `3800` to reflect the latest documented version.