### PR TITLE
Migrate Polkadot Utils to Ethers Derivation of accounts / private keys 

### DIFF
--- a/test/builders/build/substrate-api/polkadotjs-api.js
+++ b/test/builders/build/substrate-api/polkadotjs-api.js
@@ -55,13 +55,13 @@ describe('Polkadot.js API', function () {
   describe('Keyrings - Adding Accounts', async () => {
     it('should extract the ethereum address from the mnemonic', async () => {
       // Derive using BIP-39 + BIP-44 via ethers
-      const wallet = HDNodeWallet.fromPhrase(alice.mnemonic, null, ethDerPath);
+      const wallet = HDNodeWallet.fromPhrase(alice.mnemonic, undefined, ethDerPath);
       assert.equal(wallet.address, alice.address);
     });
 
     it('should extract the private key from the mnemonic', async () => {
       // Derive using BIP-39 + BIP-44 via ethers
-      const wallet = HDNodeWallet.fromPhrase(alice.mnemonic, null, ethDerPath);
+      const wallet = HDNodeWallet.fromPhrase(alice.mnemonic, undefined, ethDerPath);
       const privateKey = wallet.privateKey; // 0x-prefixed
       assert.equal(privateKey, alice.pk);
     });


### PR DESCRIPTION
This pull request updates the Polkadot.js API test suite to use the `ethers` library for mnemonic-based Ethereum key derivation instead of relying on Polkadot-specific utilities. The main focus is on improving consistency and simplifying the derivation process for Ethereum addresses and private keys in tests.

Keyring and key derivation improvements:

* Replaced the use of Polkadot's `Keyring` and utility functions (`u8aToHex`, `mnemonicToLegacySeed`, `hdEthereum`) for deriving Ethereum addresses and private keys from mnemonics with the `ethers.Wallet.fromPhrase` method, ensuring BIP-39 + BIP-44 compliance and simplifying the code. [[1]](diffhunk://#diff-88f8a33e396d4a3c759f19d18da1f3f418ce0621e24a9a198ecef82e80d7d023L4-L5) [[2]](diffhunk://#diff-88f8a33e396d4a3c759f19d18da1f3f418ce0621e24a9a198ecef82e80d7d023L59-R68)

Test suite modernization:

* Updated tests for extracting Ethereum addresses and private keys from mnemonics to use `ethers.Wallet` instead of Polkadot utilities, improving maintainability and aligning with Ethereum standards.

No changes were made to transaction signing or batch transaction tests.