### PR TITLE
Moonriver XC-20 Asset Revision

### DIFF
--- a/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
+++ b/test/builders/interoperability/xcm/xc20/overview/retrieve-xc20s.js
@@ -24,7 +24,7 @@ describe('Overview of XC-20s - Current List of External XC-20s', function () {
     it('should return the correct counter for XC-20s on Moonriver', async () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const counter = await api.query.evmForeignAssets.counterForAssetsById();
-      assert.equal(counter.toNumber(), 24);
+      assert.equal(counter.toNumber(), 28);
       api.disconnect();
     }).timeout(15000);
 


### PR DESCRIPTION
This pull request updates a test to reflect the current number of XC-20 assets on Moonriver. The only change is to adjust the expected value in an assertion to match the updated asset count.

* Updated the expected XC-20 asset counter in the Moonriver test from 24 to 28 in `retrieve-xc20s.js` to reflect the current state of the network.