### PR TITLE
3900 Runtime Moonriver

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -21,7 +21,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 3800);
+      assert.equal(runtime.toJSON().specVersion, 3900);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonbeam', async () => {


### PR DESCRIPTION
This pull request updates the runtime version check in the Moonriver network test to match the latest documented spec version.

* Testing: Updated the expected `specVersion` in the Moonriver runtime upgrade test from `3800` to `3900` in `test/builders/build/runtime-upgrades.js` to reflect the latest version.