### PR TITLE
Bump runtime test suite to rt4300

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -21,7 +21,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 4202);
+      assert.equal(runtime.toJSON().specVersion, 4300);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonbeam', async () => {


### PR DESCRIPTION
This pull request updates a test to reflect the latest Moonriver runtime version.

- Test maintenance:
  * Updated the expected `specVersion` in the Moonriver runtime upgrade test from `4202` to `4300` to match the latest documented version.
