### PR TITLE
Bump  runtime version 

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -14,21 +14,21 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonbase.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 4300);
+      assert.equal(runtime.toJSON().specVersion, 4302);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonriver', async () => {
       const api = await getApi('wss://wss.api.moonriver.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 4300);
+      assert.equal(runtime.toJSON().specVersion, 4303);
       api.disconnect();
     });
     it('should return the latest runtime version for Moonbeam', async () => {
       const api = await getApi('wss://wss.api.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 4203);
+      assert.equal(runtime.toJSON().specVersion, 4204);
       api.disconnect();
     });
   });


### PR DESCRIPTION
This pull request updates the expected runtime versions in the `Runtime Upgrades` test suite to match the latest versions documented for Moonbase, Moonriver, and Moonbeam. This ensures that the tests accurately reflect the current state of the networks.