### PR TITLE
Bump runtime test suite to rt4303

### DIFF
--- a/test/builders/build/runtime-upgrades.js
+++ b/test/builders/build/runtime-upgrades.js
@@ -28,7 +28,7 @@ describe('Runtime Upgrades', () => {
       const api = await getApi('wss://wss.api.moonbeam.network');
       const runtime = await api.query.system.lastRuntimeUpgrade();
       // Assert the runtime is equal to the latest version we have on the docs
-      assert.equal(runtime.toJSON().specVersion, 4202);
+      assert.equal(runtime.toJSON().specVersion, 4303);
       api.disconnect();
     });
   });


### PR DESCRIPTION
This pull request updates the runtime test suite assertions to reflect the Moonbeam 4303 runtime upgrade.

**Moonbeam 4303 Upgrade Updates:**
- Updated the Moonbeam runtime assertion from `4204` to `4303`.